### PR TITLE
Fixed Packer build VirtualBox permissions issue

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches-ignore:
       - main
+  workflow_dispatch: {}
 jobs:
   development:
     uses: ./.github/workflows/packer-build.yml

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches-ignore:
       - main
-  workflow_dispatch: {}
 jobs:
   development:
     uses: ./.github/workflows/packer-build.yml

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --dearmor -o /usr/share/keyrings/oracle-virtualbox-2016.gpg
           echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt-get update && sudo apt-get install virtualbox-7.0
+          sudo apt-get update && sudo apt-get install virtualbox-6.0
 
       - name: "Checkout code"
         uses: actions/checkout@v4

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -48,6 +48,7 @@ jobs:
         if: ${{ inputs.release == false }}
         working-directory: packer
         run: |
+          env USER=$LOGNAME
           packer build \
           -except "vagrant-cloud" \
           .

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --dearmor -o /usr/share/keyrings/oracle-virtualbox-2016.gpg
           echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt-get update && sudo apt-get install virtualbox-6.0
+          sudo apt-get update && sudo apt-get install virtualbox-7.0
 
       - name: "Checkout code"
         uses: actions/checkout@v4

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -48,8 +48,7 @@ jobs:
         if: ${{ inputs.release == false }}
         working-directory: packer
         run: |
-          env USER=$LOGNAME
-          packer build \
+          sudo packer build \
           -except "vagrant-cloud" \
           .
 

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -21,15 +21,15 @@ jobs:
     steps:
       - name: "Install Packer"
         run: |
-          wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt-get update && sudo apt-get install packer
+          wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
+          apt-get update && apt-get install packer
 
       - name: "Install VirtualBox"
         run: |
-          wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --dearmor -o /usr/share/keyrings/oracle-virtualbox-2016.gpg
-          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt-get update && sudo apt-get install virtualbox-7.0
+          wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | gpg --dearmor -o /usr/share/keyrings/oracle-virtualbox-2016.gpg
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | tee /etc/apt/sources.list.d/hashicorp.list
+          apt-get update && apt-get install virtualbox-7.0
 
       - name: "Checkout code"
         uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
         if: ${{ inputs.release == false }}
         working-directory: packer
         run: |
-          sudo packer build \
+          packer build \
           -except "vagrant-cloud" \
           .
 

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -21,15 +21,15 @@ jobs:
     steps:
       - name: "Install Packer"
         run: |
-          wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
-          apt-get update && apt-get install packer
+          wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt-get update && sudo apt-get install packer
 
       - name: "Install VirtualBox"
         run: |
-          wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | gpg --dearmor -o /usr/share/keyrings/oracle-virtualbox-2016.gpg
-          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | tee /etc/apt/sources.list.d/hashicorp.list
-          apt-get update && apt-get install virtualbox-7.0
+          wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --dearmor -o /usr/share/keyrings/oracle-virtualbox-2016.gpg
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt-get update && sudo apt-get install virtualbox-7.0
 
       - name: "Checkout code"
         uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
         if: ${{ inputs.release == false }}
         working-directory: packer
         run: |
-          packer build \
+          sudo packer build \
           -except "vagrant-cloud" \
           .
 
@@ -56,7 +56,7 @@ jobs:
         if: ${{ inputs.release == true }}
         working-directory: packer
         run: |
-          packer build \
+          sudo packer build \
           -var "version=${{ inputs.version }}" \
           -var "access_token=${{ secrets.ACCESS_TOKEN }}" \
           -var "version_description=Build $(date +'%Y-%m-%d')" \

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -23,13 +23,13 @@ jobs:
         run: |
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt update && sudo apt install packer
+          sudo apt-get update && sudo apt-get install packer
 
       - name: "Install VirtualBox"
         run: |
           wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --dearmor -o /usr/share/keyrings/oracle-virtualbox-2016.gpg
           echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian $(lsb_release -cs) contrib" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt update && sudo apt install virtualbox-7.0
+          sudo apt-get update && sudo apt-get install virtualbox-7.0
 
       - name: "Checkout code"
         uses: actions/checkout@v4


### PR DESCRIPTION
There was an issue with the `packer build` command which caused the builds to fail. I've changed the code to use `sudo` so that the build command is run as root.

Closes #5 